### PR TITLE
Conditionally include the epel class

### DIFF
--- a/manifests/build.pp
+++ b/manifests/build.pp
@@ -73,16 +73,18 @@ define slurm::build(
 
   case $::osfamily {
     'Redhat': {
-      include ::epel
       include ::yum
       if !defined(Yum::Group[$slurm::params::groupinstall]) {
         yum::group { $slurm::params::groupinstall:
           ensure  => 'present',
           timeout => 600,
-          require => Class['::epel'],
         }
       }
       Yum::Group[$slurm::params::groupinstall] -> Exec[$buildname]
+      if $slurm::manage_epel {
+        include ::epel
+        Yum::Group[$slurm::params::groupinstall] -> Class['::epel']
+      }
 
       $rpmdir = "${dir}/RPMS/${::architecture}"
       $rpms   = prefix(suffix(concat($slurm::params::common_rpms_basename, $slurm::params::slurmdbd_rpms_basename), "-${version}*.rpm"), "${rpmdir}/")

--- a/manifests/common/redhat.pp
+++ b/manifests/common/redhat.pp
@@ -9,14 +9,17 @@
 # Specialization class for Redhat systems
 class slurm::common::redhat inherits slurm::common {
 
-  include ::epel
   include ::yum
   include ::selinux
 
   yum::group { $slurm::params::groupinstall:
     ensure  => 'present',
     timeout => 600,
-    require => Class['::epel'],
+  }
+
+  if $slurm::manage_epel {
+    include ::epel
+    Yum::Group[$slurm::params::groupinstall] -> Class['::epel']
   }
 
   # Resource default statements

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -424,6 +424,7 @@ class slurm(
   Boolean $manage_firewall                = $slurm::params::manage_firewall,
   Boolean $manage_munge                   = $slurm::params::manage_munge,
   Boolean $manage_pam                     = $slurm::params::manage_pam,
+  Boolean $manage_epel                    = $slurm::params::manage_epel,
   Boolean $service_manage                 = $slurm::params::service_manage,
   Integer $uid                            = $slurm::params::uid,
   Integer $gid                            = $slurm::params::gid,

--- a/manifests/install/packages.pp
+++ b/manifests/install/packages.pp
@@ -92,7 +92,10 @@ define slurm::install::packages(
 
   case $::osfamily {
     'Redhat': {
-      include ::epel
+      if $slurm::manage_epel {
+        include ::epel
+      }
+
       include ::yum
       $rpms   = suffix($pkgs, '*.rpm')
       $cwddir = "${pkgdir}/RPMS/${::architecture}"

--- a/manifests/munge.pp
+++ b/manifests/munge.pp
@@ -69,7 +69,7 @@ inherits slurm::params
   validate_legacy('String',  'validate_re',   $ensure, ['^present', '^absent'])
   #validate_legacy('Boolean', 'validate_bool', $create_key)
 
-  if ($::osfamily == 'RedHat') {
+  if ($::osfamily == 'RedHat' and $slurm::manage_epel) {
     include ::epel
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,6 +57,8 @@ class slurm::params {
   $manage_firewall   = false
   # Whether or not this module should manage the accounting
   $manage_accounting = false
+  # Whether or not this module should manage epel
+  $manage_epel = true
 
   # Configuration directory & file
   $configdir = $::operatingsystem ? {


### PR DESCRIPTION
This allows the use of this module in environments where the EPEL
repository is managed or provided by some other mechanism than the
stahnma/epel Puppet-module.